### PR TITLE
Add bilingual landing page for mona

### DIFF
--- a/mona.html
+++ b/mona.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>mona</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      text-align: center;
+      padding-top: 50px;
+    }
+    .lang { display: none; }
+    .active { display: block; }
+  </style>
+  <script>
+    function switchLang(lang) {
+      document.querySelectorAll('.lang').forEach(function(el){ el.classList.remove('active'); });
+      document.querySelector('.lang-' + lang).classList.add('active');
+    }
+  </script>
+</head>
+<body>
+  <div>
+    <button onclick="switchLang('ja')">日本語</button>
+    <button onclick="switchLang('en')">English</button>
+  </div>
+  <div class="lang lang-ja active">
+    <h1>mona</h1>
+    <h2>OVER HUMAN INTELLIGENCE</h2>
+    <p>眠らず動く、超知性</p>
+  </div>
+  <div class="lang lang-en">
+    <h1>mona</h1>
+    <h2>OVER HUMAN INTELLIGENCE</h2>
+    <p>Unceasing in stride, SuperIntelligence</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `mona.html` with company name OVER HUMAN INTELLIGENCE and bilingual catchphrase
- include buttons to switch between Japanese and English content without Google Translate

## Testing
- `npx -y htmlhint mona.html`

------
https://chatgpt.com/codex/tasks/task_e_68be835ea9ec832cad9e3c2b2f935d12